### PR TITLE
Make Rails 7.0 the min supported version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Issues are tracked at https://github.com/roberts1000/autorequire_rails/issues. Issues marked as **(Internal)** only affect development.
 
+## Next Release
+
+1. [#82](../../issues/82): Make Rails 7.0 the min supported version.
+
 ## 2.0.0 (Jun 03, 2024)
 
 1. [#60](../../issues/60): Update dev gems. **(Internal)**

--- a/autorequire_rails.gemspec
+++ b/autorequire_rails.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 3.1.0'
 
-  spec.add_dependency "rails", ">= 7.1"
+  spec.add_dependency "rails", ">= 7.0"
 end


### PR DESCRIPTION
<!-- Replace XYZ with the related GitHub issue number -->

Closes #82